### PR TITLE
fix: remove useless test variable

### DIFF
--- a/tests/CryptTest.php
+++ b/tests/CryptTest.php
@@ -335,7 +335,7 @@ class CryptTest extends TestCase
         $this->expectException(CryptException::class);
         $this->expectExceptionMessage('Characters cannot be empty');
 
-        $randomString = Crypt::getRandomString(25, '');
+        Crypt::getRandomString(25, '');
     }
 
     // endregion


### PR DESCRIPTION
## Description
Remove useless test variable

## Changelist
- remove useless test variable in `tests/CryptTest.php`